### PR TITLE
Harden shutdown flow, thread synchronization, and Tosu HTTP boundaries

### DIFF
--- a/abs-c.c
+++ b/abs-c.c
@@ -16,28 +16,27 @@
 #include <limits.h>
 #include <sys/stat.h>
 #include <pwd.h>
+#include <errno.h>
 #include "tosuhandler.h"
 
 #define INACTIVE_SLEEP_MS 100  // long sleep to save CPU
 
 volatile sig_atomic_t stop = 0;
-int tab_fd;
+int tab_fd = -1;
 int fd = -1;
 
-void quit(int sig) {
+static void quit(int sig) {
     (void)sig;
-    printf("\nExiting.\n");
     stop = 1;
-    if (fd > 0) ioctl(fd, EVIOCGRAB, 0);
-    if (tab_fd) ioctl(tab_fd, UI_DEV_DESTROY);
-    tosu_shutdown();
-    exit(0);
 }
 
 static inline void set_grab(int fd, bool *grabbed, bool want) {
     if (*grabbed == want) return;
-    if (ioctl(fd, EVIOCGRAB, want) == 0)
+    if (ioctl(fd, EVIOCGRAB, want) == 0) {
         *grabbed = want;
+    } else {
+        perror("ioctl EVIOCGRAB");
+    }
 }
 
 // Internal helper: returns malloc'd home directory for the real user.
@@ -127,14 +126,21 @@ static int handler(void* user, const char* section, const char* name, const char
 
 int init_uinput(int tmin_x, int tmax_x, int tmin_y, int tmax_y) {
     int fd = open("/dev/uinput", O_WRONLY | O_NONBLOCK);
-    if (fd < 0) { perror("open /dev/uinput"); exit(EXIT_FAILURE); }
+    if (fd < 0) {
+        perror("open /dev/uinput");
+        return -1;
+    }
 
-    ioctl(fd, UI_SET_EVBIT, EV_KEY);
-    ioctl(fd, UI_SET_KEYBIT, BTN_LEFT);
-    ioctl(fd, UI_SET_EVBIT, EV_ABS);
-    ioctl(fd, UI_SET_ABSBIT, ABS_X);
-    ioctl(fd, UI_SET_ABSBIT, ABS_Y);
-    ioctl(fd, UI_SET_EVBIT, EV_SYN);
+    if (ioctl(fd, UI_SET_EVBIT, EV_KEY) < 0 ||
+        ioctl(fd, UI_SET_KEYBIT, BTN_LEFT) < 0 ||
+        ioctl(fd, UI_SET_EVBIT, EV_ABS) < 0 ||
+        ioctl(fd, UI_SET_ABSBIT, ABS_X) < 0 ||
+        ioctl(fd, UI_SET_ABSBIT, ABS_Y) < 0 ||
+        ioctl(fd, UI_SET_EVBIT, EV_SYN) < 0) {
+        perror("ioctl uinput setup");
+        close(fd);
+        return -1;
+    }
 
     struct uinput_user_dev uidev = {0};
     snprintf(uidev.name, UINPUT_MAX_NAME_SIZE, "Abs-C Virtual Tablet");
@@ -147,8 +153,17 @@ int init_uinput(int tmin_x, int tmax_x, int tmin_y, int tmax_y) {
     uidev.absmin[ABS_Y] = tmin_y;
     uidev.absmax[ABS_Y] = tmax_y;
 
-    write(fd, &uidev, sizeof(uidev));
-    ioctl(fd, UI_DEV_CREATE);
+    ssize_t wrote = write(fd, &uidev, sizeof(uidev));
+    if (wrote != (ssize_t)sizeof(uidev)) {
+        perror("write uinput_user_dev");
+        close(fd);
+        return -1;
+    }
+    if (ioctl(fd, UI_DEV_CREATE) < 0) {
+        perror("ioctl UI_DEV_CREATE");
+        close(fd);
+        return -1;
+    }
     return fd;
 }
 
@@ -212,7 +227,7 @@ void list_devices() {
     free(namelist);
 }
 
-static inline void emit_abs_delta(int x, int y, bool x_dirty, bool y_dirty) {
+static inline bool emit_abs_delta(int x, int y, bool x_dirty, bool y_dirty) {
     struct input_event ev[3];
     int n = 0;
 
@@ -239,13 +254,27 @@ static inline void emit_abs_delta(int x, int y, bool x_dirty, bool y_dirty) {
         .value = 0
     };
 
-    write(tab_fd, ev, n * sizeof(struct input_event));
+    ssize_t wrote = write(tab_fd, ev, n * sizeof(struct input_event));
+    if (wrote != (ssize_t)(n * sizeof(struct input_event))) {
+        perror("write EV_ABS");
+        return false;
+    }
+    return true;
 }
 
 
 int main(int argc, char *argv[]) {
-    signal(SIGINT, quit);
-    signal(SIGTERM, quit);
+    int exit_code = EXIT_FAILURE;
+    bool grabbed = false;
+    bool tosu_started = false;
+
+    struct sigaction sa = {0};
+    sa.sa_handler = quit;
+    sigemptyset(&sa.sa_mask);
+    if (sigaction(SIGINT, &sa, NULL) < 0 || sigaction(SIGTERM, &sa, NULL) < 0) {
+        perror("sigaction");
+        goto cleanup;
+    }
 
     check_caps(argv[0]);
 
@@ -274,24 +303,32 @@ int main(int argc, char *argv[]) {
 
     const char *dev_override = NULL;
     for (int i = 1; i < argc; i++) {
-        if (!strcmp(argv[i], "-h") || !strcmp(argv[i], "--help")) { print_help(argv[0]); return 0; }
-        else if (!strcmp(argv[i], "-l") || !strcmp(argv[i], "--list")) { list_devices(); return 0; }
+        if (!strcmp(argv[i], "-h") || !strcmp(argv[i], "--help")) { print_help(argv[0]); exit_code = EXIT_SUCCESS; goto cleanup; }
+        else if (!strcmp(argv[i], "-l") || !strcmp(argv[i], "--list")) { list_devices(); exit_code = EXIT_SUCCESS; goto cleanup; }
         else if ((!strcmp(argv[i], "-d") || !strcmp(argv[i], "--device")) && i+1<argc) dev_override = argv[++i];
     }
 
     struct dirent **namelist;
     int ndevs = scandir("/dev/input/", &namelist, NULL, alphasort);
-    if (ndevs < 0) { perror("scandir"); exit(EXIT_FAILURE); }
+    if (ndevs < 0) { perror("scandir"); goto cleanup; }
 
     char path[256], name[256];
     bool found = false, usable = false;
 
     for (int i = 0; i < ndevs && !found; i++) {
+        if (strcmp(namelist[i]->d_name, ".") == 0 || strcmp(namelist[i]->d_name, "..") == 0) {
+            continue;
+        }
         snprintf(path, sizeof(path), "/dev/input/%s", namelist[i]->d_name);
         int devfd = open(path, O_RDONLY);
         if (devfd < 0) continue;
 
-        ioctl(devfd, EVIOCGNAME(sizeof(name)), name);
+        if (ioctl(devfd, EVIOCGNAME(sizeof(name)), name) < 0) {
+            perror("ioctl EVIOCGNAME");
+            close(devfd);
+            continue;
+        }
+        name[sizeof(name) - 1] = '\0';
 
         if (dev_override) {
             if (dev_override[0] == '/' && strcmp(path, dev_override) != 0) { close(devfd); continue; }
@@ -300,13 +337,21 @@ int main(int argc, char *argv[]) {
 
         unsigned long evbits[(EV_MAX + (sizeof(unsigned long)*8) - 1) /
         (sizeof(unsigned long)*8)] = {0};
-        ioctl(devfd, EVIOCGBIT(0, sizeof(evbits)), evbits);
+        if (ioctl(devfd, EVIOCGBIT(0, sizeof(evbits)), evbits) < 0) {
+            perror("ioctl EVIOCGBIT");
+            close(devfd);
+            continue;
+        }
 
         if (test_bit(EV_ABS, evbits)) {
             unsigned long absbits[(ABS_MAX + (sizeof(unsigned long)*8) - 1) /
             (sizeof(unsigned long)*8)] = {0};
 
-            ioctl(devfd, EVIOCGBIT(EV_ABS, sizeof(absbits)), absbits);
+            if (ioctl(devfd, EVIOCGBIT(EV_ABS, sizeof(absbits)), absbits) < 0) {
+                perror("ioctl EVIOCGBIT(EV_ABS)");
+                close(devfd);
+                continue;
+            }
 
             bool has_x = test_bit(ABS_X, absbits);
             bool has_y = test_bit(ABS_Y, absbits);
@@ -315,23 +360,31 @@ int main(int argc, char *argv[]) {
                 fd = devfd;
                 found = usable = true;
                 printf("Using device %s (%s)\n", path, name);
+                devfd = -1;
             }
         }
 
-        else if (dev_override) { found = true; usable = false; close(devfd); }
-        else close(devfd);
+        else if (dev_override) { found = true; usable = false; }
+
+        if (devfd >= 0) close(devfd);
     }
 
     for (int i = 0; i < ndevs; i++) free(namelist[i]);
     free(namelist);
 
-    if (!found) { fprintf(stderr, dev_override ? "No device matching '%s'\n" : "No suitable input device found.\n", dev_override); exit(EXIT_FAILURE); }
-    if (!usable) { fprintf(stderr, "Device '%s' is not usable (requires EV_ABS support)\n", dev_override);  exit(EXIT_FAILURE); }
+    if (!found) { fprintf(stderr, dev_override ? "No device matching '%s'\n" : "No suitable input device found.\n", dev_override); goto cleanup; }
+    if (!usable) { fprintf(stderr, "Device '%s' is not usable (requires EV_ABS support)\n", dev_override); goto cleanup; }
 
     struct input_absinfo absinfo;
-    ioctl(fd, EVIOCGABS(ABS_X), &absinfo);
+    if (ioctl(fd, EVIOCGABS(ABS_X), &absinfo) < 0) {
+        perror("ioctl EVIOCGABS(ABS_X)");
+        goto cleanup;
+    }
     int tmin_x = absinfo.minimum, tmax_x = absinfo.maximum;
-    ioctl(fd, EVIOCGABS(ABS_Y), &absinfo);
+    if (ioctl(fd, EVIOCGABS(ABS_Y), &absinfo) < 0) {
+        perror("ioctl EVIOCGABS(ABS_Y)");
+        goto cleanup;
+    }
     int tmin_y = absinfo.minimum, tmax_y = absinfo.maximum;
 
     double sr = (double)config.display_width / config.display_height;
@@ -356,10 +409,15 @@ int main(int argc, char *argv[]) {
     int new_tmax_y = (int)(y_center + y_half_range);
 
     tab_fd = init_uinput(new_tmin_x, new_tmax_x, new_tmin_y, new_tmax_y);
+    if (tab_fd < 0) goto cleanup;
 
     struct sched_param param = {.sched_priority=20};
-    sched_setscheduler(0, SCHED_FIFO, &param);
-    mlockall(MCL_CURRENT | MCL_FUTURE);
+    if (sched_setscheduler(0, SCHED_FIFO, &param) < 0) {
+        perror("sched_setscheduler");
+    }
+    if (mlockall(MCL_CURRENT | MCL_FUTURE) < 0) {
+        perror("mlockall");
+    }
 
     struct pollfd pfd = {.fd=fd, .events=POLLIN};
     struct input_event ev_buf[64];
@@ -369,10 +427,10 @@ int main(int argc, char *argv[]) {
     int x = 0, y = 0;
     int x_old = -1, y_old = -1;
     bool active;
-    bool grabbed = false;
 
     if (config.enable_tosu == true) {
         tosu_init();
+        tosu_started = true;
     }
     else {
         printf("Tosu integration is disabled.\n");
@@ -399,9 +457,19 @@ int main(int argc, char *argv[]) {
         if (active == true) {
             if (poll(&pfd, 1, -1) <= 0)
                 continue;
+            if (pfd.revents & (POLLERR | POLLHUP | POLLNVAL)) {
+                fprintf(stderr, "poll error on input device\n");
+                break;
+            }
 
             struct input_event ev;
-            if (read(fd, &ev, sizeof(ev)) != sizeof(ev))
+            ssize_t rd = read(fd, &ev, sizeof(ev));
+            if (rd < 0) {
+                if (errno == EINTR && stop) break;
+                perror("read input_event");
+                continue;
+            }
+            if (rd != sizeof(ev))
                 continue;
 
             bool x_dirty = false;
@@ -418,7 +486,9 @@ int main(int argc, char *argv[]) {
                 }
 
                 if (x_dirty || y_dirty) {
-                    emit_abs_delta(x, y, x_dirty, y_dirty);
+                    if (!emit_abs_delta(x, y, x_dirty, y_dirty)) {
+                        break;
+                    }
                     x_old = x;
                     y_old = y;
                 }
@@ -432,7 +502,11 @@ int main(int argc, char *argv[]) {
                     { .type = EV_KEY, .code = BTN_LEFT, .value = ev.value },
                     { .type = EV_SYN, .code = SYN_REPORT, .value = 0 }
                 };
-                write(tab_fd, btn, sizeof(btn));
+                ssize_t bw = write(tab_fd, btn, sizeof(btn));
+                if (bw != (ssize_t)sizeof(btn)) {
+                    perror("write BTN_LEFT");
+                    break;
+                }
             }
         }
         else {
@@ -443,5 +517,26 @@ int main(int argc, char *argv[]) {
             nanosleep(&ts, NULL);
         }
     }
-    return 0;
+    exit_code = EXIT_SUCCESS;
+
+cleanup:
+    if (grabbed && fd >= 0 && ioctl(fd, EVIOCGRAB, 0) < 0) {
+        perror("ioctl EVIOCGRAB release");
+    }
+    if (tosu_started) {
+        tosu_shutdown();
+    }
+    if (tab_fd >= 0) {
+        if (ioctl(tab_fd, UI_DEV_DESTROY) < 0) {
+            perror("ioctl UI_DEV_DESTROY");
+        }
+        close(tab_fd);
+        tab_fd = -1;
+    }
+    if (fd >= 0) {
+        close(fd);
+        fd = -1;
+    }
+    fprintf(stderr, "Exiting with status %d\n", exit_code);
+    return exit_code;
 }

--- a/tosuhandler.c
+++ b/tosuhandler.c
@@ -7,6 +7,8 @@
 #include <stdio.h>
 #include <unistd.h>
 #include <time.h>
+#include <errno.h>
+#include <stdatomic.h>
 #include <curl/curl.h>
 #include <cjson/cJSON.h>
 
@@ -23,7 +25,8 @@ struct curl_buf {
 static pthread_t poll_thread;
 static pthread_mutex_t state_mutex = PTHREAD_MUTEX_INITIALIZER;
 
-static bool running = false;
+static _Atomic bool running = false;
+static bool thread_started = false;
 static bool last_abs_state = false;
 
 /* Track previous menu state and whether we're currently treating the session as a replay.
@@ -147,29 +150,62 @@ static void *poll_thread_func(void *arg) {
 
     if (!multi || !easy) {
         fprintf(stderr, "[tosu] curl init failed\n");
+        if (easy) curl_easy_cleanup(easy);
+        if (multi) curl_multi_cleanup(multi);
         return NULL;
     }
 
-    curl_easy_setopt(easy, CURLOPT_URL, TOSU_URL);
-    curl_easy_setopt(easy, CURLOPT_TIMEOUT_MS, 500);
-    curl_easy_setopt(easy, CURLOPT_FOLLOWLOCATION, 1L);
-    curl_easy_setopt(easy, CURLOPT_WRITEFUNCTION, curl_write_cb);
+    if (curl_easy_setopt(easy, CURLOPT_URL, TOSU_URL) != CURLE_OK ||
+        curl_easy_setopt(easy, CURLOPT_TIMEOUT_MS, 500L) != CURLE_OK ||
+        curl_easy_setopt(easy, CURLOPT_FOLLOWLOCATION, 0L) != CURLE_OK ||
+        curl_easy_setopt(easy, CURLOPT_PROTOCOLS_STR, "http") != CURLE_OK ||
+        curl_easy_setopt(easy, CURLOPT_REDIR_PROTOCOLS_STR, "http") != CURLE_OK ||
+        curl_easy_setopt(easy, CURLOPT_WRITEFUNCTION, curl_write_cb) != CURLE_OK) {
+        fprintf(stderr, "[tosu] curl_easy_setopt failed\n");
+        curl_easy_cleanup(easy);
+        curl_multi_cleanup(multi);
+        return NULL;
+    }
 
-    while (running) {
+    while (atomic_load_explicit(&running, memory_order_acquire)) {
         struct curl_buf buf = {0};
 
-        curl_easy_setopt(easy, CURLOPT_WRITEDATA, &buf);
-        curl_multi_add_handle(multi, easy);
-
-        int still_running = 0;
-        curl_multi_perform(multi, &still_running);
-
-        while (still_running && running) {
-            curl_multi_poll(multi, NULL, 0, 100, NULL);
-            curl_multi_perform(multi, &still_running);
+        if (curl_easy_setopt(easy, CURLOPT_WRITEDATA, &buf) != CURLE_OK) {
+            fprintf(stderr, "[tosu] failed to set WRITEDATA\n");
+            break;
+        }
+        CURLMcode mrc = curl_multi_add_handle(multi, easy);
+        if (mrc != CURLM_OK) {
+            fprintf(stderr, "[tosu] curl_multi_add_handle failed: %s\n", curl_multi_strerror(mrc));
+            break;
         }
 
-        curl_multi_remove_handle(multi, easy);
+        int still_running = 0;
+        mrc = curl_multi_perform(multi, &still_running);
+        if (mrc != CURLM_OK) {
+            fprintf(stderr, "[tosu] curl_multi_perform failed: %s\n", curl_multi_strerror(mrc));
+            curl_multi_remove_handle(multi, easy);
+            break;
+        }
+
+        while (still_running && atomic_load_explicit(&running, memory_order_acquire)) {
+            mrc = curl_multi_poll(multi, NULL, 0, 100, NULL);
+            if (mrc != CURLM_OK) {
+                fprintf(stderr, "[tosu] curl_multi_poll failed: %s\n", curl_multi_strerror(mrc));
+                break;
+            }
+            mrc = curl_multi_perform(multi, &still_running);
+            if (mrc != CURLM_OK) {
+                fprintf(stderr, "[tosu] curl_multi_perform failed: %s\n", curl_multi_strerror(mrc));
+                break;
+            }
+        }
+
+        mrc = curl_multi_remove_handle(multi, easy);
+        if (mrc != CURLM_OK) {
+            fprintf(stderr, "[tosu] curl_multi_remove_handle failed: %s\n", curl_multi_strerror(mrc));
+            break;
+        }
 
         if (buf.data) {
             cJSON *root = cJSON_Parse(buf.data);
@@ -199,9 +235,13 @@ static void *poll_thread_func(void *arg) {
                 .tv_sec = POLL_INTERVAL_MS / 1000,
                 .tv_nsec = (POLL_INTERVAL_MS % 1000) * 1000000L
             };
-            nanosleep(&ts, NULL);
+            if (nanosleep(&ts, NULL) < 0 && errno != EINTR) {
+                perror("[tosu] nanosleep");
+                break;
+            }
 
     }
+    atomic_store_explicit(&running, false, memory_order_release);
 
     curl_easy_cleanup(easy);
     curl_multi_cleanup(multi);
@@ -218,25 +258,50 @@ void tosu_set_state_change_callback(void (*cb)(bool)) {
 
 // ---------------- PUBLIC API ----------------
 void tosu_init(void) {
-    if (running) return;
-
-    curl_global_init(CURL_GLOBAL_DEFAULT);
-
     pthread_mutex_lock(&state_mutex);
+    bool already_running = atomic_load_explicit(&running, memory_order_acquire);
+    if (already_running || thread_started) {
+        pthread_mutex_unlock(&state_mutex);
+        return;
+    }
     last_abs_state = false;
     last_menu_state = -1;
     replay_session = false;
     pthread_mutex_unlock(&state_mutex);
 
-    running = true;
-    pthread_create(&poll_thread, NULL, poll_thread_func, NULL);
+    CURLcode gc = curl_global_init(CURL_GLOBAL_DEFAULT);
+    if (gc != CURLE_OK) {
+        fprintf(stderr, "[tosu] curl_global_init failed: %s\n", curl_easy_strerror(gc));
+        return;
+    }
+
+    atomic_store_explicit(&running, true, memory_order_release);
+    int rc = pthread_create(&poll_thread, NULL, poll_thread_func, NULL);
+    if (rc != 0) {
+        fprintf(stderr, "[tosu] pthread_create failed: %d\n", rc);
+        atomic_store_explicit(&running, false, memory_order_release);
+        curl_global_cleanup();
+        return;
+    }
+
+    pthread_mutex_lock(&state_mutex);
+    thread_started = true;
+    pthread_mutex_unlock(&state_mutex);
 }
 
 void tosu_shutdown(void) {
-    if (!running) return;
+    pthread_mutex_lock(&state_mutex);
+    bool join_needed = thread_started;
+    thread_started = false;
+    pthread_mutex_unlock(&state_mutex);
 
-    running = false;
-    pthread_join(poll_thread, NULL);
+    if (!join_needed) return;
+
+    atomic_store_explicit(&running, false, memory_order_release);
+    int rc = pthread_join(poll_thread, NULL);
+    if (rc != 0) {
+        fprintf(stderr, "[tosu] pthread_join failed: %d\n", rc);
+    }
 
     curl_global_cleanup();
 }


### PR DESCRIPTION
### Motivation
- Eliminate unsafe work from signal handlers and centralize teardown so shutdown is async-signal-safe and deterministic. 
- Remove data races and make the Tosu polling thread lifecycle robust and observable from the main thread. 
- Prevent file-descriptor/resource leaks and reduce silent network trust expansion via redirects during Tosu polling.

### Description
- Replaced ad-hoc signal handling in `abs-c.c` with a minimal `sigaction` handler that only sets `stop` and moved all teardown into a single `cleanup:` path executed by normal control flow.  Added deterministic EVIOCGRAB release, uinput device destroy, Tosu shutdown and FD closure. 
- Hardened `init_uinput`, ABS emission and button writes in `abs-c.c` by checking `open`/`ioctl`/`write`/`read` return values and returning/handling errors instead of assuming success.  `emit_abs_delta` now returns a status to propagate write failures. 
- Refactored `/dev/input` discovery in `abs-c.c` so every opened `devfd` is closed on non-selected branches and the chosen device is retained explicitly; early-continue/error branches now close descriptors. 
- Reworked Tosu polling in `tosuhandler.c` to use `_Atomic bool running` and a guarded `thread_started` flag, made the polling loop read `running` atomically, and validated `pthread_create` and `pthread_join` results before assuming thread state. 
- Added defensive checks and diagnostics around curl usage in `tosuhandler.c`: check `curl_global_init`, validate `curl_easy_setopt` and `curl_multi_*` return codes, clean up handles on failures, and constrain HTTP trust by disabling automatic redirects and limiting allowed protocols/redirect protocols to `http` for the local endpoint.

### Testing
- Ran the project build with `make -C /workspace/Abs-C`; the build failed in this environment due to missing development headers/libraries (`ini.h` and `cjson/cJSON.h`), so compilation could not be fully verified here.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d55e356428832aadefaed928c75608)