### PR TITLE
Harden Tosu init, poll handling, and local request trust

### DIFF
--- a/abs-c.c
+++ b/abs-c.c
@@ -10,6 +10,7 @@
 #include <string.h>
 #include <ini.h>
 #include <poll.h>
+#include <errno.h>
 #include <sched.h>
 #include <sys/mman.h>
 #include <sys/capability.h>
@@ -362,17 +363,15 @@ int main(int argc, char *argv[]) {
     mlockall(MCL_CURRENT | MCL_FUTURE);
 
     struct pollfd pfd = {.fd=fd, .events=POLLIN};
-    struct input_event ev_buf[64];
-
-
 
     int x = 0, y = 0;
     int x_old = -1, y_old = -1;
-    bool active;
+    bool active = false;
     bool grabbed = false;
 
     if (config.enable_tosu == true) {
         tosu_init();
+        active = tosu_get_absolute_state();
     }
     else {
         printf("Tosu integration is disabled.\n");
@@ -397,7 +396,23 @@ int main(int argc, char *argv[]) {
         set_grab(fd, &grabbed, active);
 
         if (active == true) {
-            if (poll(&pfd, 1, -1) <= 0)
+            int poll_rc = poll(&pfd, 1, -1);
+            if (poll_rc == -1) {
+                if (errno == EINTR) {
+                    if (stop) break;
+                    continue;
+                }
+                perror("poll");
+                break;
+            }
+            if (poll_rc == 0)
+                continue;
+
+            if (pfd.revents & (POLLERR | POLLHUP | POLLNVAL)) {
+                fprintf(stderr, "poll: fatal revents=0x%x\n", pfd.revents);
+                break;
+            }
+            if (!(pfd.revents & POLLIN))
                 continue;
 
             struct input_event ev;

--- a/tosuhandler.c
+++ b/tosuhandler.c
@@ -11,7 +11,7 @@
 #include <cjson/cJSON.h>
 
 // ---------------- CONFIG ----------------
-#define TOSU_URL "http://localhost:24050/json"
+#define TOSU_URL "http://127.0.0.1:24050/json"
 #define POLL_INTERVAL_MS 500
 // ----------------------------------------
 
@@ -153,6 +153,7 @@ static void *poll_thread_func(void *arg) {
     curl_easy_setopt(easy, CURLOPT_URL, TOSU_URL);
     curl_easy_setopt(easy, CURLOPT_TIMEOUT_MS, 500);
     curl_easy_setopt(easy, CURLOPT_FOLLOWLOCATION, 1L);
+    curl_easy_setopt(easy, CURLOPT_NOPROXY, "*");
     curl_easy_setopt(easy, CURLOPT_WRITEFUNCTION, curl_write_cb);
 
     while (running) {


### PR DESCRIPTION
### Motivation
- Prevent use of an uninitialized `active` when Tosu integration is enabled. 
- Make the main input loop handle `poll()` errors and interrupts explicitly instead of treating any non-positive return as a silent continue. 
- Reduce local trust surface for Tosu HTTP requests and remove an unused dead local in `main`.

### Description
- Initialize `active` to `false` and, when Tosu is enabled, set `active = tosu_get_absolute_state()` immediately after `tosu_init()` in `abs-c.c` to avoid uninitialized reads.
- Replace the condensed `if (poll(&pfd, 1, -1) <= 0) continue;` with explicit handling: check `poll()` return value, continue on `EINTR` (unless `stop` is set), call `perror("poll")` and break on hard errors, continue on timeout (`0`), preserve fatal `pfd.revents` checks and require `POLLIN` before reading.
- Remove the unused `struct input_event ev_buf[64];` declaration from `main` in `abs-c.c`.
- Add `#include <errno.h>` to support robust `poll()` errno checks.
- In `tosuhandler.c`, change `TOSU_URL` from `http://localhost:24050/json` to `http://127.0.0.1:24050/json` and set `CURLOPT_NOPROXY` to `"*"` to prevent environment proxying while preserving existing redirect and protocol settings.
- Inspected `emit_abs_delta` and made no change because there was no duplicated unreachable `return false;` in the current tree.

### Testing
- Ran `git diff -- abs-c.c tosuhandler.c` to verify the code delta (succeeded).
- Ran `git status --short` to confirm staged changes (succeeded).
- Ran `make clean && make` to attempt a build; the build failed in this environment due to missing development headers/libraries (`ini.h`, `cjson/cJSON.h`) and not due to the applied changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d560a457f0832a9ba40a55bc03ad07)