### PR TITLE
Only scan character `event*` devices and silence EVIOCGNAME perror

### DIFF
--- a/abs-c.c
+++ b/abs-c.c
@@ -313,18 +313,31 @@ int main(int argc, char *argv[]) {
     if (ndevs < 0) { perror("scandir"); goto cleanup; }
 
     char path[256], name[256];
+    struct stat st;
     bool found = false, usable = false;
 
     for (int i = 0; i < ndevs && !found; i++) {
         if (strcmp(namelist[i]->d_name, ".") == 0 || strcmp(namelist[i]->d_name, "..") == 0) {
             continue;
         }
+
+        if (strncmp(namelist[i]->d_name, "event", 5) != 0) {
+            continue;
+        }
+
         snprintf(path, sizeof(path), "/dev/input/%s", namelist[i]->d_name);
+
+        if (stat(path, &st) < 0) {
+            continue;
+        }
+        if (!S_ISCHR(st.st_mode)) {
+            continue;
+        }
+
         int devfd = open(path, O_RDONLY);
         if (devfd < 0) continue;
 
         if (ioctl(devfd, EVIOCGNAME(sizeof(name)), name) < 0) {
-            perror("ioctl EVIOCGNAME");
             close(devfd);
             continue;
         }


### PR DESCRIPTION
### Motivation
- Reduce noise and failure cases by skipping non-`event*` entries and non-character files when enumerating `/dev/input`, and avoid printing an error for failed `EVIOCGNAME` ioctls.

### Description
- Add `struct stat` and a `stat()` check to skip non-character files and only process entries whose name begins with `event` before opening them, and remove the `perror` call for a failed `ioctl(..., EVIOCGNAME, ...)`.

### Testing
- Built the program with `gcc -Wall` and ran a basic device enumeration smoke test using `./abs-c --list`, which succeeded without spurious errors.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d563fc24a0832ab5e23b754d7c0102)